### PR TITLE
feature: adds "output" mode, resolves #270

### DIFF
--- a/exercises/primitive_types/primitive_types4.rs
+++ b/exercises/primitive_types/primitive_types4.rs
@@ -8,7 +8,4 @@
 fn slice_out_of_array() {
     let a = [1, 2, 3, 4, 5];
 
-    let nice_slice = ???
-
-    assert_eq!([2, 3, 4], nice_slice)
 }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -1,4 +1,4 @@
-use crate::exercise::{Exercise, Mode, State};
+use crate::exercise::{CompiledExercise, Exercise, Mode, State};
 use console::style;
 use indicatif::ProgressBar;
 
@@ -6,7 +6,7 @@ pub fn verify<'a>(start_at: impl IntoIterator<Item = &'a Exercise>) -> Result<()
     for exercise in start_at {
         let compile_result = match exercise.mode {
             Mode::Test => compile_and_test(&exercise, RunMode::Interactive),
-            Mode::Compile => compile_only(&exercise),
+            Mode::Compile => compile_and_run_interactively(&exercise),
             Mode::Clippy => compile_only(&exercise),
         };
         if !compile_result.unwrap_or(false) {
@@ -30,23 +30,37 @@ fn compile_only(exercise: &Exercise) -> Result<bool, ()> {
     let progress_bar = ProgressBar::new_spinner();
     progress_bar.set_message(format!("Compiling {}...", exercise).as_str());
     progress_bar.enable_steady_tick(100);
-    let compilation_result = exercise.compile();
+
+    let _ = compile(&exercise, &progress_bar)?;
     progress_bar.finish_and_clear();
 
-    match compilation_result {
-        Ok(_) => {
-            success!("Successfully compiled {}!", exercise);
-            Ok(prompt_for_completion(&exercise))
-        }
+    success!("Successfully compiled {}!", exercise);
+    Ok(prompt_for_completion(&exercise, None))
+}
+
+fn compile_and_run_interactively(exercise: &Exercise) -> Result<bool, ()> {
+    let progress_bar = ProgressBar::new_spinner();
+    progress_bar.set_message(format!("Compiling {}...", exercise).as_str());
+    progress_bar.enable_steady_tick(100);
+
+    let compilation = compile(&exercise, &progress_bar)?;
+
+    progress_bar.set_message(format!("Running {}...", exercise).as_str());
+    let result = compilation.run();
+    progress_bar.finish_and_clear();
+
+    let output = match result {
+        Ok(output) => output,
         Err(output) => {
-            warn!(
-                "Compilation of {} failed! Compiler error message:\n",
-                exercise
-            );
-            println!("{}", output.stderr);
-            Err(())
+            warn!("Ran {} with errors", exercise);
+            println!("{}", output.stdout);
+            return Err(());
         }
-    }
+    };
+
+    success!("Successfully ran {}!", exercise);
+
+    Ok(prompt_for_completion(&exercise, Some(output.stdout)))
 }
 
 fn compile_and_test(exercise: &Exercise, run_mode: RunMode) -> Result<bool, ()> {
@@ -54,28 +68,15 @@ fn compile_and_test(exercise: &Exercise, run_mode: RunMode) -> Result<bool, ()> 
     progress_bar.set_message(format!("Testing {}...", exercise).as_str());
     progress_bar.enable_steady_tick(100);
 
-    let compilation_result = exercise.compile();
-
-    let compilation = match compilation_result {
-        Ok(compilation) => compilation,
-        Err(output) => {
-            progress_bar.finish_and_clear();
-            warn!(
-                "Compiling of {} failed! Please try again. Here's the output:",
-                exercise
-            );
-            println!("{}", output.stderr);
-            return Err(());
-        }
-    };
-
+    let compilation = compile(exercise, &progress_bar)?;
     let result = compilation.run();
     progress_bar.finish_and_clear();
 
     match result {
         Ok(_) => {
+            success!("Successfully tested {}", &exercise);
             if let RunMode::Interactive = run_mode {
-                Ok(prompt_for_completion(&exercise))
+                Ok(prompt_for_completion(&exercise, None))
             } else {
                 Ok(true)
             }
@@ -91,7 +92,27 @@ fn compile_and_test(exercise: &Exercise, run_mode: RunMode) -> Result<bool, ()> 
     }
 }
 
-fn prompt_for_completion(exercise: &Exercise) -> bool {
+fn compile<'a, 'b>(
+    exercise: &'a Exercise,
+    progress_bar: &'b ProgressBar,
+) -> Result<CompiledExercise<'a>, ()> {
+    let compilation_result = exercise.compile();
+
+    match compilation_result {
+        Ok(compilation) => Ok(compilation),
+        Err(output) => {
+            progress_bar.finish_and_clear();
+            warn!(
+                "Compiling of {} failed! Please try again. Here's the output:",
+                exercise
+            );
+            println!("{}", output.stderr);
+            Err(())
+        }
+    }
+}
+
+fn prompt_for_completion(exercise: &Exercise, prompt_output: Option<String>) -> bool {
     let context = match exercise.state() {
         State::Done => return true,
         State::Pending(context) => context,
@@ -106,6 +127,15 @@ fn prompt_for_completion(exercise: &Exercise) -> bool {
     println!("");
     println!("🎉 🎉  {} 🎉 🎉", success_msg);
     println!("");
+
+    if let Some(output) = prompt_output {
+        println!("Output:");
+        println!("{}", separator());
+        println!("{}", output);
+        println!("{}", separator());
+        println!("");
+    }
+
     println!("You can keep working on this exercise,");
     println!(
         "or jump into the next one by removing the {} comment:",
@@ -128,4 +158,8 @@ fn prompt_for_completion(exercise: &Exercise) -> bool {
     }
 
     false
+}
+
+fn separator() -> console::StyledObject<&'static str> {
+    style("====================").bold()
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -31,7 +31,7 @@ fn verify_all_success() {
 }
 
 #[test]
-fn verify_all_failure() {
+fn verify_fails_if_some_fails() {
     Command::cargo_bin("rustlings")
         .unwrap()
         .arg("v")


### PR DESCRIPTION
* New: `mode = "output`.
* If `output = "foobar"` is specified for an `"output"` exercise, it runs a "test" against the expected output.
* An `"output"` exercise prints its output in the `🎉 Move on when you're ready` screen. 

<details>

<summary> Screenshots </summary>

![Screenshot at 2020-02-26 21:52:49](https://user-images.githubusercontent.com/1636604/75386792-94c4cc80-58e2-11ea-90da-95d0aa35f20e.png)
![Screenshot at 2020-02-26 21:52:23](https://user-images.githubusercontent.com/1636604/75386794-955d6300-58e2-11ea-8a3c-9e67394c3e19.png)


</details>

After playing a while with this, I'm not entirely sold on the idea :sweat_smile: I think having expected output _could_ be useful in a very exploratory exercise like "Get `main` to print `Hello world!` to the screen". But, in general, I feel like `"test"` exercises guide you better toward the answer. Take `structs1.rs` for instance and its hypothetical alternative:

<details>

<summary> <code>structs1.rs</code> </summary>


```rust
struct ColorClassicStruct {
    // TODO: Something goes here
}

struct ColorTupleStruct(/* TODO: Something goes here */);

#[derive(Debug)]
struct UnitStruct;

#[cfg(test)]
mod tests {
    use super::*;

    #[test]
    fn classic_c_structs() {
        // TODO: Instantiate a classic c struct!
        // let green =

        assert_eq!(green.name, "green");
        assert_eq!(green.hex, "#00FF00");
    }

    #[test]
    fn tuple_structs() {
        // TODO: Instantiate a tuple struct!
        // let green =

        assert_eq!(green.0, "green");
        assert_eq!(green.1, "#00FF00");
    }

    #[test]
    fn unit_structs() {
        // TODO: Instantiate a unit struct!
        // let unit_struct =
        let message = format!("{:?}s are fun!", unit_struct);

        assert_eq!(message, "UnitStructs are fun!");
    }
}
```

</details>


<details>

<summary> <code>structs1.rs</code> with <code>"output"</code> </summary>

```rust
struct ColorClassicStruct {
    // TODO: Something goes here
}

struct ColorTupleStruct(/* TODO: Something goes here */);

#[derive(Debug)]
struct UnitStruct;

fn main() {
    // TODO: Instantiate a classic c struct!
    // let green =
    println!("green.name = {}", green.name);
    println!("green.hex = {}", green.hex);

    // etc.
}
```

</details>

I don't think it works quite as well, since the learner has no clue what the value of `green.name` should be until they get the program to compile and see the Expected/Actual error message. And it'll be way harder to reach that point without the clue on what the fields of `ColorClassicStruct` should be. I suspect we could blame the exercise itself. Others, like `if1.rs`, might work better.

What I do think it works great is non-expected output exercises. Most of the `"compile"` exercises felt a bit anti-climatic. Once you get the program to compile, you can still play with it thanks to `I AM NOT DONE`, but you don't _see_ the results of your tweaks. Even if we don't adopt `mode="output"`, I think the default behavior of `"compile"` should be this.

So, summary of options:
1. Scrub this, make `"compile"` always print output.
2. Keep this PR as it is. It might be useful in future exercises, or maybe you have a strong opinion that some `mode = "test"` exercises should be converted.
    * If we keep it, we could still make `"compile"` always print as in (1) and
    reserve `mode = "output"` for mandatory expected output (i.e. change `Mode::Output(Option<String>)` to `Mode::Output(String)`).