### PR TITLE
chore: add result1.rs to exercise list

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -507,6 +507,12 @@ get a warning if you don't handle a `Result` that you get in your
 function. Read more about that in the `std::result` module docs:
 https://doc.rust-lang.org/std/result/#results-must-be-used"""
 
+[[exercises]]
+name = "result1"
+path = "exercises/error_handling/result1.rs"
+mode = "test"
+hint = "No hints this time ;)"
+
 # OPTIONS / RESULTS
 
 [[exercises]]


### PR DESCRIPTION
[result1.rs](https://github.com/fmoko/rustlings/blob/master/exercises/error_handling/result1.rs) is missing in `info.toml`