### PR TITLE
feat: Add exercise variables6 covering const

### DIFF
--- a/exercises/variables/variables6.rs
+++ b/exercises/variables/variables6.rs
@@ -1,0 +1,9 @@
+// variables5.rs
+// Make me compile! Execute the command `rustlings hint variables6` if you want a hint :)
+
+// I AM NOT DONE
+
+const NUMBER = 3;
+fn main() {
+    println!("Number {}", NUMBER);
+}

--- a/info.toml
+++ b/info.toml
@@ -56,6 +56,21 @@ You can read more about 'Shadowing' in the book's section 'Variables and Mutabil
 https://doc.rust-lang.org/book/ch03-01-variables-and-mutability.html#shadowing
 Try to solve this exercise afterwards using this technique."""
 
+[[exercises]]
+name = "variables6"
+path = "exercises/variables/variables6.rs"
+mode = "compile"
+hint = """
+We know about variables and mutability, but there is another important type of 
+variable available; constants. 
+Constants are always immutable and they are declared with keyword 'const' rather 
+then keyword 'let'.
+Constants types must also always be annotated.
+
+Read more about constants under 'Differences Between Variables and Constants' in the book's section 'Variables and Mutability': 
+https://doc.rust-lang.org/book/ch03-01-variables-and-mutability.html
+"""
+
 # IF
 
 [[exercises]]


### PR DESCRIPTION
The 'Variables and Mutability' section of [The Book](https://doc.rust-lang.org/stable/book/ch03-01-variables-and-mutability.html) introduces the _const_ keyword. However, that seemed to not be covered by the variables exercises. 